### PR TITLE
Subscription fixes

### DIFF
--- a/includes/class-wc-gateway-mondido-hw.php
+++ b/includes/class-wc-gateway-mondido-hw.php
@@ -6,7 +6,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Gateway_Mondido_HW extends WC_Gateway_Mondido_Abstract {
 
     protected $preselected_method = null;
-    protected $logger = null;
 
 	/**
 	 * Init

--- a/includes/class-wc-mondido-api.php
+++ b/includes/class-wc-mondido-api.php
@@ -48,6 +48,38 @@ class WC_Mondido_Api {
 		]);
 	}
 
+	public function list_plans() {
+		return $this->list_all(__METHOD__, "v1/plans", []);
+	}
+
+	public function list_customer_subscriptions($customer_id) {
+		return $this->get(__METHOD__, "v1/customers/$customer_id/subscriptions", ['extend' => 'plan']);
+	}
+
+	public function cancel_subscription($id) {
+		return $this->put(__METHOD__, "v1/subscriptions/$id", ['status' => 'cancelled']);
+	}
+
+	private function list_all($context, $path, $query) {
+		$query = $query + ['limit' => 100, 'offset' => 0];
+		$result = [];
+
+		if ($query['limit'] == 0) {
+			return $result;
+		}
+
+		do {
+			$items = $this->send_request('GET', $path, $context, $query, []);
+			if (is_wp_error($items)) {
+				return $items;
+			}
+			$result = array_merge($result, $items);
+            $query['offset'] += $query['limit'];
+		} while (count($items) === $query['limit']);
+
+		return $result;
+	}
+
 	private function get($context, $path, $query) {
 		return $this->send_request('GET', $path, $context, $query, []);
 	}

--- a/includes/class-wc-mondido-subscriptions-account.php
+++ b/includes/class-wc-mondido-subscriptions-account.php
@@ -5,18 +5,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 class WC_Mondido_Subscriptions_Account {
+    private $api;
+    private $gateway;
 	/**
 	 * Constructor
 	 */
-	public function __construct() {
+	public function __construct($api, $gateway) {
+        $this->api = $api;
+        $this->gateway = $gateway;
+
 		add_action( 'init', array( $this, 'add_endpoints' ) );
 		add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
 		add_filter( 'woocommerce_account_menu_items', array( $this, 'menu_items' ) );
 		add_filter( 'the_title', array( $this, 'endpoint_title' ) );
 		add_action( 'woocommerce_account_mondido-subscriptions_endpoint', array( $this, 'endpoint_content' ) );
-		add_action( 'after_switch_theme', array( __CLASS__, 'flush_rewrite_rules' ) );
-
-
+		add_action( 'after_switch_theme', array( $this, 'flush_rewrite_rules' ) );
 
 		add_action( 'wp_ajax_mondido_cancel_subscription', array( $this, 'cancel_subscription' ) );
 	}
@@ -56,7 +59,9 @@ class WC_Mondido_Subscriptions_Account {
 	 * @return array
 	 */
 	public function menu_items( $items ) {
-		$items['mondido-subscriptions'] = __( 'Mondido Subscriptions', 'woocommerce-gateway-mondido' );
+		if (count($this->get_subscriptions()) > 0) {
+			$items['mondido-subscriptions'] = __( 'Mondido Subscriptions', 'woocommerce-gateway-mondido' );
+		}
 
 		return $items;
 	}
@@ -88,25 +93,11 @@ class WC_Mondido_Subscriptions_Account {
 	 * Endpoint HTML content
 	 */
 	public function endpoint_content() {
-		$user_id = get_current_user_id();
-
-		$subscriptions = array();
-		$references = $this->getMondidoGateway()->getCustomerReferences( $user_id );
-		foreach ( $references as $reference ) {
-			$customer_id = $this->getMondidoGateway()->getMondidoCustomerId( $reference['customer_reference'] );
-			if ( ! $customer_id ) {
-				continue;
-			}
-
-			$result = $this->getMondidoGateway()->getMondidoSubscriptions( $customer_id );
-			$subscriptions = array_merge($subscriptions, $result);
-		}
-
 		wc_get_template(
 			'myaccount/mondido-subscriptions.php',
 			array(
 				'user_id'   => $user_id,
-				'subscriptions'  => $subscriptions,
+				'subscriptions'  => array_reverse($this->get_subscriptions()),
 			),
 			'',
 			dirname( __FILE__ ) . '/../templates/'
@@ -114,66 +105,51 @@ class WC_Mondido_Subscriptions_Account {
 	}
 
 	/**
-	 * Get Mondido Gateway Instance
-	 * @return WC_Gateway_Mondido_HW
-	 */
-	public static function getMondidoGateway()
-	{
-		$payment_gateways = WC()->payment_gateways->payment_gateways();
-		return $payment_gateways['mondido_hw'];
-	}
-
-	/**
-	 * Get Subscription Plan
-	 * @param $plan_id
-	 *
-	 * @return array|bool|mixed|object
-	 */
-	public static function getSubscriptionPlan($plan_id)
-	{
-		try {
-			$result = self::getMondidoGateway()->getSubscriptionPlan( $plan_id );
-		} catch (Exception $e) {
-			return false;
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Format Subscription Description
-	 * @param array $subscription
-	 *
-	 * @return string
-	 */
-	public static function formatSubscriptionDescription( array $subscription )
-	{
-		$plan_id = $subscription['plan']['id'];
-		$plan = self::getSubscriptionPlan( $plan_id );
-		if ( ! $plan ) {
-			return sprintf( __( 'Subscription #%s', 'woocommerce-gateway-mondido' ), $subscription['id'] );
-		}
-
-		$description = ( ! empty( $plan['description'] ) ? '(' . $plan['description'] . ')' : '');
-		return sprintf( __( '%s %s (Subscription #%s)', 'woocommerce-gateway-mondido' ), $plan['name'], $description, $subscription['id'] );
-	}
-
-	/**
 	 * Cancel Mondido Subscription
 	 */
 	public function cancel_subscription() {
-		if ( ! check_ajax_referer( 'mondido_subscriptions', 'nonce', false ) ) {
+		if ( !is_user_logged_in() || ! check_ajax_referer( 'mondido_subscriptions', 'nonce', false ) ) {
 			exit( 'No naughty business' );
 		}
 
-		$subscription_id = wc_clean( $_POST['id'] );
-		$result = self::getMondidoGateway()->cancelMondidoSubscription( $subscription_id );
-		if ($result['status'] === 'cancelled') {
-			wp_send_json_success( __( 'Success', 'woocommerce-gateway-mondido' ) );
-		} else {
-			wp_send_json_error( __( 'Failed to cancel subscription', 'woocommerce-gateway-mondido' ) );
+		$customer_subscriptions = $this->get_subscriptions();
+
+		foreach ($customer_subscriptions as $subscription) {
+			if ($subscription->id === (int) $_POST['id']) {
+				$result = $this->api->cancel_subscription( $subscription->id );
+				if (!is_wp_error($result) && $result->stauts === 'cancelled') {
+					wp_send_json_success( __( 'Success', 'woocommerce-gateway-mondido' ) );
+					return;
+				} else {
+					break;
+				}
+			}
 		}
+
+		wp_send_json_error( __( 'Failed to cancel subscription', 'woocommerce-gateway-mondido' ) );
+	}
+
+	private function get_subscriptions() {
+		if (!is_user_logged_in()) {
+			return [];
+		}
+		$user_id = get_current_user_id();
+
+		$subscriptions = [];
+		$references = $this->gateway->getCustomerReferences( $user_id );
+		foreach ( $references as $reference ) {
+			$customer_id = $this->gateway->getMondidoCustomerId( $reference['customer_reference'] );
+			if ( ! $customer_id ) {
+				continue;
+			}
+
+			$result = $this->api->list_customer_subscriptions( $customer_id );
+			if (is_wp_error($result)) {
+				return [];
+			}
+			$subscriptions = array_merge($subscriptions, $result);
+		}
+
+		return $subscriptions;
 	}
 }
-
-new WC_Mondido_Subscriptions_Account();

--- a/includes/class-wc-mondido-subscriptions.php
+++ b/includes/class-wc-mondido-subscriptions.php
@@ -5,16 +5,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 class WC_Mondido_Subscriptions {
+
+	private $api;
+
 	/**
 	 * Constructor
 	 */
-	public function __construct() {
+	public function __construct($api) {
+		$this->api = $api;
+
 		// Mondido Subscriptions
-		add_filter( 'woocommerce_product_data_tabs', __CLASS__ . '::add_product_tabs' );
-		add_action( 'woocommerce_product_data_panels', __CLASS__ . '::subscription_options_product_tab_content' );
-		add_action( 'woocommerce_process_product_meta', __CLASS__ . '::save_subscription_field' );
-		add_filter( 'woocommerce_cart_needs_payment', __CLASS__ . '::cart_needs_payment', 10, 2 );
-		add_filter( 'woocommerce_order_needs_payment', __CLASS__ . '::order_needs_payment', 10, 3 );
+		add_filter( 'woocommerce_product_data_tabs', [$this, 'add_product_tabs'] );
+		add_action( 'woocommerce_product_data_panels', [$this, 'subscription_options_product_tab_content'] );
+		add_action( 'woocommerce_process_product_meta', [$this, 'save_subscription_field'] );
+		add_filter( 'woocommerce_cart_needs_payment', [$this, 'cart_needs_payment'], 10, 2 );
+		add_filter( 'woocommerce_order_needs_payment', [$this, 'order_needs_payment'], 10, 3 );
 	}
 
 	/**
@@ -24,7 +29,7 @@ class WC_Mondido_Subscriptions {
 	 *
 	 * @return array
 	 */
-	public static function add_product_tabs( $tabs ) {
+	public function add_product_tabs( $tabs ) {
 		$tabs['mondido_subscription'] = array(
 			'label'  => __( 'Mondido Subscription', 'woocommerce-gateway-mondido' ),
 			'target' => 'subscription_options',
@@ -37,64 +42,49 @@ class WC_Mondido_Subscriptions {
 	/**
 	 * Tab Content
 	 */
-	public static function subscription_options_product_tab_content() {
+	public function subscription_options_product_tab_content() {
 		global $post;
-		$plan_id = get_post_meta( get_the_ID(), '_mondido_plan_id', TRUE );
-		$include = get_post_meta( get_the_ID(), '_mondido_plan_include', TRUE );
-		$gateways = WC()->payment_gateways->payment_gateways();
-		$gateway = $gateways['mondido_hw'];
-		?>
-		<div id='subscription_options' class='panel woocommerce_options_panel'>
-			<div class='options_group'>
-				<?php
-				try {
-					$plans   = $gateway->getSubscriptionPlans();
-					$options    = array();
-					$options[0] = __( 'No subscription', 'woocommerce-gateway-mondido' );
-					if ( $plans ) {
-						foreach ( $plans as $item ) {
-							$options[ $item['id'] ] = __( $item['name'], 'woocommerce-gateway-mondido' );
-						}
-					}
+		$plans   = $this->api->list_plans();
+		$error = null;
 
-					woocommerce_wp_select(
-						array(
-							'id'      => '_mondido_plan_id',
-							'value'   => (string) $plan_id,
-							'label'   => __( 'Subscription plan', 'woocommerce-gateway-mondido' ),
-							'options' => $options
-						)
-					);
-					woocommerce_wp_checkbox(
-						array(
-							'id'          => '_mondido_plan_include',
-                            'label'       => '',
-							'description' => __( 'Add product to the recurring payments', 'woocommerce-gateway-mondido' ),
-							'value'   => (string) $include,
-						)
-					);
-				} catch (Exception $e) {
-					?>
-					<p class="form-field _mondido_plan_id_field ">
-						<input type="hidden" name="_mondido_plan_id" value="<?php echo esc_attr( $plan_id ); ?>" />
-						<span id="message" class="error">
-					<?php echo sprintf( esc_html__( 'Mondido Error: %s', 'woocommerce-gateway-mondido' ), $e->getMessage() ); ?>
-							<br />
-							<?php _e( 'Please check Mondido settings.', 'woocommerce-gateway-mondido' ); ?>
-				</span>
-					</p>
-					<?php
-				}
-				?>
-			</div>
-		</div>
-		<?php
+		if (is_wp_error($plans)) {
+			$error = implode( $plans->errors['http_request_failed'] );
+			$plans = [];
+		}
+
+		$options = array(__( 'No subscription', 'woocommerce-gateway-mondido' ));
+
+		foreach ( $plans as $item ) {
+			if ($item->status !== 'active') {
+				continue;
+			}
+			$options[ $item->id ] = __( $item->name, 'woocommerce-gateway-mondido' );
+		}
+
+		foreach ( $plans as $item ) {
+			if ($item->status === 'active') {
+				continue;
+			}
+			$options[ $item->id ] = __( $item->name, 'woocommerce-gateway-mondido' ) . " ($item->status)";
+		}
+
+		wc_get_template(
+			'admin/product-subscription.php',
+			array(
+				'error' => $error,
+				'plan_id' => (string) get_post_meta( get_the_ID(), '_mondido_plan_id', TRUE ),
+				'include' => (string) get_post_meta( get_the_ID(), '_mondido_plan_include', TRUE ),
+				'options' => $options,
+			),
+			'',
+			dirname( __FILE__ ) . '/../templates/'
+		);
 	}
 
 	/**
 	 * Save Handler
 	 */
-	public static function save_subscription_field() {
+	public function save_subscription_field() {
 		global $post_id;
 
 		if ( empty( $post_id ) ) {
@@ -115,7 +105,7 @@ class WC_Mondido_Subscriptions {
 	 *
 	 * @return mixed
 	 */
-	public static function cart_needs_payment( $needs_payment, $cart ) {
+	public function cart_needs_payment( $needs_payment, $cart ) {
 		if ( $needs_payment === FALSE ) {
 			$products = $cart->get_cart();
 			foreach ( $products as $id => $product ) {
@@ -138,7 +128,7 @@ class WC_Mondido_Subscriptions {
 	 *
 	 * @return bool
 	 */
-	public static function order_needs_payment( $needs_payment, $order, $valid_order_statuses ) {
+	public function order_needs_payment( $needs_payment, $order, $valid_order_statuses ) {
 		if ( $needs_payment === FALSE ) {
 			foreach ( $order->get_items( 'line_item' ) as $order_item ) {
 				if ( version_compare( WC()->version, '3.0', '>=' ) ) {
@@ -163,7 +153,7 @@ class WC_Mondido_Subscriptions {
 	 *
 	 * @return string
 	 */
-	public static function remove_free_price( $price, $product ) {
+	public function remove_free_price( $price, $product ) {
 		$plan_id = get_post_meta( $product->get_id(), '_mondido_plan_id', TRUE );
 		if ( (int) $plan_id > 0 ) {
 			return '&nbsp;';
@@ -172,5 +162,3 @@ class WC_Mondido_Subscriptions {
 		return $price;
 	}
 }
-
-new WC_Mondido_Subscriptions();

--- a/includes/class-wc-mondido-transaction.php
+++ b/includes/class-wc-mondido-transaction.php
@@ -33,7 +33,7 @@ class WC_Mondido_Transaction {
 			return $subscriptions;
 		}
 
-		$data = array_merge([
+		return $this->api->create_transaction(array_merge([
 			'amount' => $amount,
 			'vat_amount' => 0,
 			'merchant_id' => $merchant_id,
@@ -66,9 +66,7 @@ class WC_Mondido_Transaction {
 			])),
 			'metadata' => $this->get_metadata($order, $customer_reference, $customer_data, $items, $payment_mode, $payment_view),
 			'payment_details' => $this->map_payment_details($customer_data),
-		], $subscriptions);
-
-		return $this->api->create_transaction($data);
+		], $subscriptions));
 	}
 
 	public function update(
@@ -229,6 +227,7 @@ class WC_Mondido_Transaction {
 			'country' => $order_country,
 			'state' => $order->get_billing_state(),
 			'email' => $order->get_billing_email(),
+			'company_name' => $order->get_billing_company(),
 		];
 	}
 
@@ -243,11 +242,12 @@ class WC_Mondido_Transaction {
 			'address_2' => $customer_data['address2'],
 			'city' => $customer_data['city'],
 			'country_code' => $customer_data['country'],
+			'company_name' => $customer_data['company_name'],
 		];
 	}
 
 	private function get_metadata($order, $customer_reference, $customer_data, $items) {
-		return [
+		$metadata = [
 			'store_order' => ['id' => $order->get_id()],
 			'customer_reference' => $customer_reference,
 			'products' => $items,
@@ -265,6 +265,8 @@ class WC_Mondido_Transaction {
 				'plugin_version' => $this->get_plugin_version(),
 			],
 		];
+		$metadata['extra'] = apply_filters('woocommerce_mondido_get_metadata_extra', [], $metadata);
+		return $metadata;
 	}
 
 	private function get_subscriptions($order) {

--- a/templates/admin/product-subscription.php
+++ b/templates/admin/product-subscription.php
@@ -1,0 +1,36 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+} // Exit if accessed directly
+?>
+<div id='subscription_options' class='panel woocommerce_options_panel'>
+    <div class='options_group'>
+        <?php if ($error): ?>
+            <p class="form-field _mondido_plan_id_field ">
+                <input type="hidden" name="_mondido_plan_id" value="<?php echo esc_attr( $plan_id ); ?>" />
+                <span id="message" class="error">
+                    <?php echo sprintf( esc_html__( 'Mondido Error: %s', 'woocommerce-gateway-mondido' ), $error ); ?>
+                    <br />
+                    <?php _e( 'Please check Mondido settings.', 'woocommerce-gateway-mondido' ); ?>
+                </span>
+            </p>
+        <?php else:
+            woocommerce_wp_select(
+                array(
+                    'id'      => '_mondido_plan_id',
+                    'value'   => $plan_id,
+                    'label'   => __( 'Subscription plan', 'woocommerce-gateway-mondido' ),
+                    'options' => $options
+                )
+            );
+            woocommerce_wp_checkbox(
+                array(
+                    'id'          => '_mondido_plan_include',
+                    'label'       => '',
+                    'description' => __( 'Add product to the recurring payments', 'woocommerce-gateway-mondido' ),
+                    'value'   => $include,
+                )
+            );
+        endif; ?>
+    </div>
+</div>

--- a/templates/myaccount/mondido-subscriptions.php
+++ b/templates/myaccount/mondido-subscriptions.php
@@ -41,16 +41,23 @@
 		</thead>
 		<tbody>
 		<?php foreach ($subscriptions as $subscription): ?>
-			<?php if ($subscription['status'] === 'active'): ?>
 			<tr>
 				<td>
-					<?php echo WC_Mondido_Subscriptions_Account::formatSubscriptionDescription( $subscription ); ?>
+					<?php printf(
+						__('%s %s (Subscription #%s)', 'woocommerce-gateway-mondido'),
+						$subscription->plan->name,
+						(!empty($subscription->plan->description) ? "({$subscription->plan->description})" : ''),
+						$subscription->id
+					); ?>
 				</td>
 				<td>
-                    <a href="#" data-id="<?php echo esc_attr( $subscription['id'] ); ?>" data-nonce="<?php echo wp_create_nonce( 'mondido_subscriptions' ); ?>" class="button view mondido-cancel"><?php _e( 'Cancel', 'woocommerce-gateway-mondido' ); ?></a>
+					<?php if ($subscription->status === 'active'): ?>
+						<a href="#" data-id="<?php echo esc_attr( $subscription->id ); ?>" data-nonce="<?php echo wp_create_nonce( 'mondido_subscriptions' ); ?>" class="button view mondido-cancel"><?php _e( 'Cancel', 'woocommerce-gateway-mondido' ); ?></a>
+					<?php else: ?>
+						<?php echo __($subscription->status, 'woocommerce-gateway-mondido'); ?>
+					<?php endif; ?>
 				</td>
 			</tr>
-			<?php endif; ?>
 		<?php endforeach; ?>
 		</tbody>
 	</table>


### PR DESCRIPTION
- Fix the limit of listing 10 plans in the admin product page
- Mark inactive plans and put them last in the admin product page
- Show cancelled subscriptions in customers subscription list
- Hide the subscription tab in customers account page if they have no subscriptions
- Add filter for metadata, to allow merchants to modify before sending it to backend
- Add company name to the transaction

## Function

## Business value

## Security considerations

## Implementation strategies

## Rollback strategies

## Test

## Steps taken

## Expected result
